### PR TITLE
[REALM-360] Add testing utilities

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 [
   inputs: [
-    "{lib,test}/**/*.{ex,exs}",
+    "{config,lib,test}/**/*.{ex,exs}",
     "mix.exs"
   ],
   locals_without_parens: [

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,20 @@
+[
+  inputs: [
+    "{lib,test}/**/*.{ex,exs}",
+    "mix.exs"
+  ],
+  locals_without_parens: [
+    # Formatter tests
+    assert_format: 2,
+    assert_format: 3,
+    assert_same: 1,
+    assert_same: 2,
+
+    # Errors tests
+    assert_eval_raise: 3,
+
+    # Mix tests
+    in_fixture: 2,
+    in_tmp: 2
+  ]
+]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,46 @@
 # KafkaMessageBus
 
-**TODO: Add description**
+A general purpose message bus.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `kafka_message_bus` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `kafka_message_bus` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:kafka_message_bus, "~> 0.1.0"}]
+  [{:kafka_message_bus, "~> 3.0"}]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/kafka_message_bus](https://hexdocs.pm/kafka_message_bus).
+## Usage
 
+The following configuration is expected:
+
+```elixir
+config :kafka_message_bus,
+  source: "source",
+  default_topic: "default_topic",
+  adapters: [
+    AdapterModule
+  ]
+```
+
+Where:
+
+|Field          |Description                                               |
+|---------------|----------------------------------------------------------|
+|`source`       |The reported message source                               |
+|`default_topic`|The default topic for any generated message               |
+|`adaters`      |A list of adapter modules. `Exq` and `Kaffe` are provided.|
+
+The adapters themselves also require some configuration.
+
+```elixir
+config :kafka_message_bus, KafkaMessageBus.Adapters.Kaffe,
+  consumers: [
+    {"kafka_topic", "kafka_resource", YourApp.ResourceConsumer}
+  ],
+  producers: ["another_topic"],
+  endpoints: ["first-broker": 9092, "second-broker": 9092],
+  namespace: "kafka_consumer_group"
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ def deps do
 end
 ```
 
+And, for now, this configuration is required:
+
+```elixir
+config :exq,
+  start_on_application: false
+```
+
 ## Usage
 
 The following configuration is expected:

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,9 @@ config :kafka_message_bus, KafkaMessageBus.Adapters.Kaffe,
   endpoints: [localhost: 9092],
   namespace: "message_bus_consumer_group"
 
+config :exq,
+	start_on_application: false
+
 config :logger,
   backends: [:console],
   level: :debug

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,47 +1,29 @@
 use Mix.Config
 
 config :kafka_message_bus,
+  source: "kafka-message-bus",
+  default_topic: "custom_kafka_topic",
   adapters: [
-    KafkaMessageBus.Adapters.Exq
-    #    KafkaMessageBus.Adapters.Kaffe
+    KafkaMessageBus.Adapters.Exq,
+    KafkaMessageBus.Adapters.Kaffe
   ]
 
 config :kafka_message_bus, KafkaMessageBus.Adapters.Exq,
   consumers: [
     {"custom_job_queue", "example_resource", KafkaMessageBusTest.Adapters.Exq.CustomJobConsumer}
   ],
+  producers: ["some_queue"],
   endpoints: [localhost: 6379],
-  namespace: "exq"
+  namespace: "message_bus_namespace"
 
 config :kafka_message_bus, KafkaMessageBus.Adapters.Kaffe,
   consumers: [
     {"custom_kafka_topic", "another_resource",
      KafkaMessageBusTest.Adapters.Kaffe.CustomJobConsumer}
   ],
+  producers: ["some_topic"],
   endpoints: [localhost: 9092],
-  namespace: "kafka_message_bus"
-
-config :kaffe,
-  consumer: [
-    endpoints: [localhost: 9092],
-    topics: ["user"],
-    consumer_group: "kafka_message_bus",
-    message_handler: KafkaMessageBus.Consumer,
-    async_message_ack: false,
-    offset_commit_interval_seconds: 10,
-    start_with_earliest_message: false,
-    rebalance_delay_ms: 100,
-    max_bytes: 10_000,
-    subscriber_retries: 5,
-    subscriber_retry_delay_ms: 5,
-    worker_allocation_strategy: :worker_per_topic_partition
-  ],
-  producer: [
-    partition_strategy: :md5,
-    endpoints: [localhost: 9092],
-    topics: ["kafka_message_bus"]
-  ],
-  kafka_mod: :brod
+  namespace: "message_bus_consumer_group"
 
 config :logger,
   backends: [:console],

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,15 +19,14 @@ config :kafka_message_bus, KafkaMessageBus.Adapters.Exq,
 
 config :kafka_message_bus, KafkaMessageBus.Adapters.Kaffe,
   consumers: [
-    {"kafka_topic", "kafka_resource",
-     KafkaMessageBusTest.Adapters.Kaffe.CustomJobConsumer}
+    {"kafka_topic", "kafka_resource", KafkaMessageBusTest.Adapters.Kaffe.CustomJobConsumer}
   ],
   producers: ["another_topic"],
   endpoints: [localhost: 9092],
   namespace: "message_bus_consumer_group"
 
 config :exq,
-	start_on_application: false
+  start_on_application: false
 
 config :logger,
   backends: [:console],

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,18 +10,19 @@ config :kafka_message_bus,
 
 config :kafka_message_bus, KafkaMessageBus.Adapters.Exq,
   consumers: [
-    {"custom_job_queue", "example_resource", KafkaMessageBusTest.Adapters.Exq.CustomJobConsumer}
+    {"job_queue", "job_resource", KafkaMessageBusTest.Adapters.Exq.CustomJobConsumer},
+    {"dead_letter_queue", nil, KafkaMessageBus.Adapters.Exq.DeadLetterQueueConsumer}
   ],
-  producers: ["some_queue"],
+  producers: ["job_queue", "dead_letter_queue"],
   endpoints: [localhost: 6379],
   namespace: "message_bus_namespace"
 
 config :kafka_message_bus, KafkaMessageBus.Adapters.Kaffe,
   consumers: [
-    {"custom_kafka_topic", "another_resource",
+    {"kafka_topic", "kafka_resource",
      KafkaMessageBusTest.Adapters.Kaffe.CustomJobConsumer}
   ],
-  producers: ["some_topic"],
+  producers: ["another_topic"],
   endpoints: [localhost: 9092],
   namespace: "message_bus_consumer_group"
 

--- a/lib/kafka_message_bus.ex
+++ b/lib/kafka_message_bus.ex
@@ -1,6 +1,4 @@
 defmodule KafkaMessageBus do
-  @moduledoc false
-
   alias KafkaMessageBus.Producer
 
   def produce(data, key, resource, action, opts \\ []) do

--- a/lib/kafka_message_bus/adapter.ex
+++ b/lib/kafka_message_bus/adapter.ex
@@ -7,7 +7,9 @@ defmodule KafkaMessageBus.Adapter do
   @type message :: Map.t()
   @type topic :: String.t()
   @type resource :: String.t()
+  @type opts :: Keyword.t()
 
   @callback start_link(config) :: {:ok, name} | {:error, reason}
-  @callback produce(message, topic, resource) :: :ok | {:error, reason}
+  @callback produce(message, opts) :: :ok | {:error, reason}
+  @callback retry(message, opts) :: :ok | {:error, reason}
 end

--- a/lib/kafka_message_bus/adapter.ex
+++ b/lib/kafka_message_bus/adapter.ex
@@ -1,0 +1,13 @@
+defmodule KafkaMessageBus.Adapter do
+  @type config :: Map.t()
+
+  @type name :: atom() | pid()
+  @type reason :: any()
+
+  @type message :: Map.t()
+  @type topic :: String.t()
+  @type resource :: String.t()
+
+  @callback start_link(config) :: {:ok, name} | {:error, reason}
+  @callback produce(message, topic, resource) :: :ok | {:error, reason}
+end

--- a/lib/kafka_message_bus/adapter.ex
+++ b/lib/kafka_message_bus/adapter.ex
@@ -1,15 +1,10 @@
 defmodule KafkaMessageBus.Adapter do
   @type config :: Map.t()
-
-  @type name :: atom() | pid()
   @type reason :: any()
-
   @type message :: Map.t()
-  @type topic :: String.t()
-  @type resource :: String.t()
   @type opts :: Keyword.t()
+  @type process_definition :: Supervisor.Spec.spec()
 
-  @callback start_link(config) :: {:ok, name} | {:error, reason}
+  @callback init(config) :: :ok | {:ok, process_definition} | {:error, reason}
   @callback produce(message, opts) :: :ok | {:error, reason}
-  @callback retry(message, opts) :: :ok | {:error, reason}
 end

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -1,0 +1,71 @@
+defmodule KafkaMessageBus.Adapters.Exq do
+  @behaviour KafkaMessageBus.Adapter
+
+  @impl true
+  def start_link(config) do
+    config
+    |> to_exq_config()
+    |> apply_exq_config()
+
+    start_exq()
+  end
+
+  @impl true
+  def produce(message, topic, resource) do
+    :exq
+    |> Application.get_env(:consumers)
+    |> Enum.flat_map(fn
+      {^topic, ^resource, module} ->
+        [module]
+
+      _ ->
+        []
+    end)
+    |> case do
+      [] ->
+        {:error, :no_consumers}
+
+      modules ->
+        Enum.each(modules, fn module ->
+          Exq.enqueue(Exq, topic, module, [message])
+        end)
+    end
+  end
+
+  defp to_exq_config(config) do
+    [{host, port} | _] = config[:endpoints]
+
+    queues =
+      Enum.map(config[:consumers], fn entry ->
+        entry
+        |> Tuple.to_list()
+        |> List.first()
+      end)
+
+    [
+      concurrency: :infinite,
+      host: Atom.to_string(host),
+      max_retries: 100,
+      name: Exq,
+      namespace: config[:namespace],
+      poll_timeout: 50,
+      port: port,
+      queues: queues,
+      scheduler_enable: true,
+      scheduler_poll_timeout: 200,
+      shutdown_timeout: 5000,
+      start_on_application: false,
+      consumers: config[:consumers]
+    ]
+  end
+
+  defp apply_exq_config(config) do
+    Enum.each(config, fn {key, value} ->
+      Application.put_env(:exq, key, value)
+    end)
+  end
+
+  defp start_exq() do
+    Exq.start_link()
+  end
+end

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -1,7 +1,7 @@
 defmodule KafkaMessageBus.Adapters.Exq do
   @behaviour KafkaMessageBus.Adapter
 
-	alias KafkaMessageBus.Config
+  alias KafkaMessageBus.Config
   alias KafkaMessageBus.Adapters.Exq.Consumer
 
   @impl true

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -2,7 +2,7 @@ defmodule KafkaMessageBus.Adapters.Exq do
   alias KafkaMessageBus.{
     Config,
     Adapter,
-    Adapter.Exq.Consumer
+    Adapters.Exq.Consumer
   }
 
   require Logger
@@ -11,9 +11,17 @@ defmodule KafkaMessageBus.Adapters.Exq do
 
   @impl Adapter
   def init(config) do
+    Logger.info(fn ->
+      "Initializing Exq adapter"
+    end)
+
     config
     |> to_exq_config()
     |> apply_exq_config()
+
+    Logger.debug(fn ->
+      "Exq configuration applied"
+    end)
 
     start_exq()
   end

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -73,11 +73,11 @@ defmodule KafkaMessageBus.Adapters.Exq do
     end)
   end
 
-  defp start_exq() do
+  defp start_exq do
     import Supervisor.Spec
-    
+
     {:ok, _} = Application.ensure_all_started(:exq)
-    
+
     {:ok, worker(Exq, [])}
   end
 end

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -1,12 +1,15 @@
 defmodule KafkaMessageBus.Adapters.Exq do
-  @behaviour KafkaMessageBus.Adapter
-
-  alias KafkaMessageBus.Config
-  alias KafkaMessageBus.Adapters.Exq.Consumer
+  alias KafkaMessageBus.{
+    Config,
+    Adapter,
+    Adapter.Exq.Consumer
+  }
 
   require Logger
 
-  @impl true
+  @behaviour Adapter
+
+  @impl Adapter
   def init(config) do
     config
     |> to_exq_config()
@@ -15,7 +18,7 @@ defmodule KafkaMessageBus.Adapters.Exq do
     start_exq()
   end
 
-  @impl true
+  @impl Adapter
   def produce(message, opts) do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     resource = message.resource

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -4,8 +4,10 @@ defmodule KafkaMessageBus.Adapters.Exq do
   alias KafkaMessageBus.Config
   alias KafkaMessageBus.Adapters.Exq.Consumer
 
+  require Logger
+
   @impl true
-  def start_link(config) do
+  def init(config) do
     config
     |> to_exq_config()
     |> apply_exq_config()
@@ -72,8 +74,10 @@ defmodule KafkaMessageBus.Adapters.Exq do
   end
 
   defp start_exq() do
+    import Supervisor.Spec
+    
     {:ok, _} = Application.ensure_all_started(:exq)
-
-    :ok
+    
+    {:ok, worker(Exq, [])}
   end
 end

--- a/lib/kafka_message_bus/adapters/exq.ex
+++ b/lib/kafka_message_bus/adapters/exq.ex
@@ -31,6 +31,8 @@ defmodule KafkaMessageBus.Adapters.Exq do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     resource = message.resource
 
+    message = Poison.encode!(message)
+
     :exq
     |> Application.get_env(:consumers)
     |> Enum.flat_map(fn

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -8,6 +8,8 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
       "Received Exq message"
     end)
 
+    message = Poison.decode!(message)
+
     Utils.set_log_metadata(message)
 
     :ok = ConsumerHandler.perform(module, message)

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -1,5 +1,5 @@
 defmodule KafkaMessageBus.Adapters.Exq.Consumer do
-  alias KafkaMessageBus.ConsumerHandler
+  alias KafkaMessageBus.{ConsumerHandler, Utils}
 
   require Logger
 
@@ -8,6 +8,13 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
       "Received Exq message"
     end)
 
+    Utils.set_log_metadata(message)
+
     :ok = ConsumerHandler.perform(module, message)
+  rescue
+    e ->
+      Utils.clear_log_metadata()
+
+      raise e
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -11,10 +11,12 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
     Utils.set_log_metadata(message)
 
     :ok = ConsumerHandler.perform(module, message)
+
+    Utils.clear_log_metadata()
   rescue
     e ->
       Utils.clear_log_metadata()
 
-      raise e
+      reraise e, __STACKTRACE__
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -4,6 +4,10 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
   require Logger
 
   def perform(module, message) do
+    Logger.info(fn ->
+      "Received Exq message"
+    end)
+
     :ok = ConsumerHandler.perform(module, message)
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -4,10 +4,6 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
   require Logger
 
   def perform(module, message) do
-    Logger.debug(fn ->
-      "Exq message received"
-    end)
-
     :ok = ConsumerHandler.perform(module, message)
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -1,7 +1,13 @@
 defmodule KafkaMessageBus.Adapters.Exq.Consumer do
-  def perform(module, message) do
-    IO.inspect({module, message})
+  alias KafkaMessageBus.ConsumerHandler
 
-    :ok
+  require Logger
+
+  def perform(module, message) do
+    Logger.debug(fn ->
+      "Exq message received"
+    end)
+
+    ConsumerHandler.perform(module, message)
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -1,0 +1,7 @@
+defmodule KafkaMessageBus.Adapters.Exq.Consumer do
+  def perform(module, message) do
+    IO.inspect({module, message})
+
+    :ok
+  end
+end

--- a/lib/kafka_message_bus/adapters/exq/consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/consumer.ex
@@ -8,6 +8,6 @@ defmodule KafkaMessageBus.Adapters.Exq.Consumer do
       "Exq message received"
     end)
 
-    ConsumerHandler.perform(module, message)
+    :ok = ConsumerHandler.perform(module, message)
   end
 end

--- a/lib/kafka_message_bus/adapters/exq/dead_letter_queue_consumer.ex
+++ b/lib/kafka_message_bus/adapters/exq/dead_letter_queue_consumer.ex
@@ -1,0 +1,15 @@
+defmodule KafkaMessageBus.Adapters.Exq.DeadLetterQueueConsumer do
+  alias KafkaMessageBus.ConsumerHandler
+
+  require Logger
+
+  def process(%{
+        "action" => "retry",
+        "data" => %{
+          "consumer" => consumer,
+          "message" => message
+        }
+      }) do
+    :ok = ConsumerHandler.perform(consumer, message)
+  end
+end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -20,7 +20,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     key = Keyword.get(opts, :key)
 
-    message = Poison.encode!(message)
+    message = Jason.encode!(message)
 
     Producer.produce_sync(topic, [{key, message}])
   end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -33,7 +33,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     key = Keyword.get(opts, :key)
 
-    message = Jason.encode!(message)
+    message = Poison.encode!(message)
 
     Producer.produce_sync(topic, [{key, message}])
   end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -13,9 +13,17 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
 
   @impl Adapter
   def init(config) do
+    Logger.info(fn ->
+      "Initializing Kaffe adapter"
+    end)
+
     config
     |> to_kaffe_config()
     |> apply_kaffe_config()
+
+    Logger.debug(fn ->
+      "Kaffe configuration applied"
+    end)
 
     start_kaffe()
   end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -27,7 +27,8 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
 
   defp to_kaffe_config(config) do
     consumer_topics =
-      Enum.map(config[:consumers], fn entry ->
+      config[:consumers]
+      |> Enum.map(fn entry ->
         entry
         |> Tuple.to_list()
         |> List.first()
@@ -66,9 +67,9 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
     end)
   end
 
-  defp start_kaffe() do
+  defp start_kaffe do
     import Supervisor.Spec
-    
+
     {:ok, _} = Application.ensure_all_started(:kaffe)
 
     {:ok, worker(Kaffe.Consumer, [])}

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -7,7 +7,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
   @behaviour KafkaMessageBus.Adapter
 
   @impl true
-  def start_link(config) do
+  def init(config) do
     config
     |> to_kaffe_config()
     |> apply_kaffe_config()
@@ -67,11 +67,10 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
   end
 
   defp start_kaffe() do
+    import Supervisor.Spec
+    
     {:ok, _} = Application.ensure_all_started(:kaffe)
 
-    Kaffe.Producer.start_producer_client()
-    Kaffe.Consumer.start_link()
-
-    :ok
+    {:ok, worker(Kaffe.Consumer, [])}
   end
 end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -1,4 +1,9 @@
 defmodule KafkaMessageBus.Adapters.Kaffe do
+  alias Kaffe.Producer
+
+	alias KafkaMessageBus.Config
+  alias KafkaMessageBus.Adapters.Kaffe.Consumer
+
   @behaviour KafkaMessageBus.Adapter
 
   @impl true
@@ -10,21 +15,32 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
     start_kaffe()
   end
 
+  @impl true
+  def produce(message, opts) do
+    topic = Keyword.get(opts, :topic, Config.default_topic())
+    key = Keyword.get(opts, :key)
+
+    message = Poison.encode!(message)
+
+    Producer.produce_sync(topic, [{key, message}])
+  end
+
   defp to_kaffe_config(config) do
-    topics =
+    consumer_topics =
       Enum.map(config[:consumers], fn entry ->
         entry
         |> Tuple.to_list()
         |> List.first()
       end)
+      |> Enum.uniq()
 
     [
       consumer: [
         heroku_kafka_env: false,
         endpoints: config[:endpoints],
-        topics: topics,
+        topics: consumer_topics,
         consumer_group: config[:namespace],
-        message_handler: KafkaMessageBus.Consumer,
+        message_handler: Consumer,
         async_message_ack: false,
         offset_commit_interval_seconds: 10,
         start_with_earliest_message: false,
@@ -37,7 +53,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
       producer: [
         partition_strategy: :md5,
         endpoints: config[:endpoints],
-        topics: topics
+        topics: config[:producers]
       ],
       kafka_mod: :brod
     ]
@@ -50,6 +66,11 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
   end
 
   defp start_kaffe() do
-    Kaffe.GroupMemberSupervisor.start_link()
+    {:ok, _} = Application.ensure_all_started(:kaffe)
+
+		Kaffe.Producer.start_producer_client()
+    Kaffe.Consumer.start_link()
+
+    :ok
   end
 end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -1,0 +1,55 @@
+defmodule KafkaMessageBus.Adapters.Kaffe do
+  @behaviour KafkaMessageBus.Adapter
+
+  @impl true
+  def start_link(config) do
+    config
+    |> to_kaffe_config()
+    |> apply_kaffe_config()
+
+    start_kaffe()
+  end
+
+  defp to_kaffe_config(config) do
+    topics =
+      Enum.map(config[:consumers], fn entry ->
+        entry
+        |> Tuple.to_list()
+        |> List.first()
+      end)
+
+    [
+      consumer: [
+        heroku_kafka_env: false,
+        endpoints: config[:endpoints],
+        topics: topics,
+        consumer_group: config[:namespace],
+        message_handler: KafkaMessageBus.Consumer,
+        async_message_ack: false,
+        offset_commit_interval_seconds: 10,
+        start_with_earliest_message: false,
+        rebalance_delay_ms: 100,
+        max_bytes: 10_000,
+        subscriber_retries: 5,
+        subscriber_retry_delay_ms: 5,
+        worker_allocation_strategy: :worker_per_topic_partition
+      ],
+      producer: [
+        partition_strategy: :md5,
+        endpoints: config[:endpoints],
+        topics: topics
+      ],
+      kafka_mod: :brod
+    ]
+  end
+
+  defp apply_kaffe_config(config) do
+    Enum.each(config, fn {key, value} ->
+      Application.put_env(:kaffe, key, value)
+    end)
+  end
+
+  defp start_kaffe() do
+    Kaffe.GroupMemberSupervisor.start_link()
+  end
+end

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -1,12 +1,17 @@
 defmodule KafkaMessageBus.Adapters.Kaffe do
   alias Kaffe.Producer
 
-  alias KafkaMessageBus.Config
-  alias KafkaMessageBus.Adapters.Kaffe.Consumer
+  alias KafkaMessageBus.{
+    Adapter,
+    Config,
+    Adapters.Kaffe.Consumer
+  }
 
-  @behaviour KafkaMessageBus.Adapter
+  require Logger
 
-  @impl true
+  @behaviour Adapter
+
+  @impl Adapter
   def init(config) do
     config
     |> to_kaffe_config()
@@ -15,7 +20,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
     start_kaffe()
   end
 
-  @impl true
+  @impl Adapter
   def produce(message, opts) do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     key = Keyword.get(opts, :key)

--- a/lib/kafka_message_bus/adapters/kaffe.ex
+++ b/lib/kafka_message_bus/adapters/kaffe.ex
@@ -1,7 +1,7 @@
 defmodule KafkaMessageBus.Adapters.Kaffe do
   alias Kaffe.Producer
 
-	alias KafkaMessageBus.Config
+  alias KafkaMessageBus.Config
   alias KafkaMessageBus.Adapters.Kaffe.Consumer
 
   @behaviour KafkaMessageBus.Adapter
@@ -55,7 +55,8 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
         endpoints: config[:endpoints],
         topics: config[:producers]
       ],
-      kafka_mod: :brod
+      kafka_mod: :brod,
+      app_consumers: config[:consumers]
     ]
   end
 
@@ -68,7 +69,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe do
   defp start_kaffe() do
     {:ok, _} = Application.ensure_all_started(:kaffe)
 
-		Kaffe.Producer.start_producer_client()
+    Kaffe.Producer.start_producer_client()
     Kaffe.Consumer.start_link()
 
     :ok

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -37,7 +37,15 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
         :ok
 
       {:error, reason} ->
-        KafkaMessageBus.produce("dead_letter_queue", nil, nil, nil)
+        Logger.error(fn ->
+          "Failed to run handler - will produce `dead_letter_queue` message. Reason: #{
+            inspect(reason)
+          }"
+        end)
+
+        message = %{"message" => message, "consumer" => consumer}
+
+        KafkaMessageBus.produce(message, nil, "failure", "retry", topic: "dead_letter_queue")
     end
   end
 

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -32,7 +32,13 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
   end
 
   defp run_consumer(consumer, message) do
-    ConsumerHandler.perform(consumer, message)
+    case ConsumerHandler.perform(consumer, message) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+          KafkaMessageBus.produce("dead_letter_queue", nil, nil, nil)
+    end
   end
 
   defp get_consumers_for(topic, resource) do

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -4,9 +4,43 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
   require Logger
 
   def handle_message(message) do
-    IO.inspect(message)
+    Logger.debug(fn ->
+      "Kaffe message received"
+    end)
 
-    :ok
-    # ConsumerHandler.perform(module, message)
+    message.value
+    |> Poison.decode()
+    |> run_consumers(message.topic)
+  end
+
+  defp run_consumers({:ok, contents}, topic) do
+    case get_consumers_for(topic, contents["resource"]) do
+      [] ->
+        Logger.error(fn ->
+          "No consumers configured for #{topic}/#{contents["resource"]}"
+        end)
+
+      consumers ->
+        Enum.each(consumers, fn consumer -> run_consumer(consumer, contents) end)
+    end
+  end
+
+  defp run_consumers({:error, message}, topic) do
+    Logger.error(fn ->
+      "Failed to decode Kaffe message on topic #{topic}: #{inspect(message)}"
+    end)
+  end
+
+  defp run_consumer(consumer, message) do
+    ConsumerHandler.perform(consumer, message)
+  end
+
+  defp get_consumers_for(topic, resource) do
+    :kaffe
+    |> Application.get_env(:app_consumers)
+    |> Enum.flat_map(fn
+      {^topic, ^resource, module} -> [module]
+      _ -> []
+    end)
   end
 end

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -1,0 +1,12 @@
+defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
+  alias KafkaMessageBus.ConsumerHandler
+
+  require Logger
+
+  def handle_message(message) do
+    IO.inspect(message)
+
+    :ok
+    # ConsumerHandler.perform(module, message)
+  end
+end

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -9,7 +9,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
     end)
 
     message.value
-    |> Poison.decode()
+    |> Jason.decode()
     |> run_consumers(message.topic)
   end
 

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -37,7 +37,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
         :ok
 
       {:error, reason} ->
-          KafkaMessageBus.produce("dead_letter_queue", nil, nil, nil)
+        KafkaMessageBus.produce("dead_letter_queue", nil, nil, nil)
     end
   end
 

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -9,7 +9,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
     end)
 
     message.value
-    |> Jason.decode()
+    |> Poison.decode()
     |> configure_logger()
     |> run_consumers(message.topic)
 
@@ -24,8 +24,8 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
     result
   end
 
-  defp configure_logger({:error, _reason} = message) do
-    message
+  defp configure_logger({:error, _reason} = result) do
+    result
   end
 
   defp run_consumers({:ok, contents}, topic) do

--- a/lib/kafka_message_bus/adapters/test_adapter.ex
+++ b/lib/kafka_message_bus/adapters/test_adapter.ex
@@ -1,0 +1,44 @@
+defmodule KafkaMessageBus.Adapters.TestAdapter do
+  @behaviour KafkaMessageBus.Adapter
+
+  use Agent
+
+  alias KafkaMessageBus.Config
+
+  def init(config) do
+    import Supervisor.Spec
+
+    child = worker(Agent, [fn -> build_initial_state(config) end, [name: __MODULE__]])
+
+    {:ok, child}
+  end
+
+  defp build_initial_state(config) do
+    %{
+      producers: config[:producers],
+      messages: %{}
+    }
+  end
+
+  def produce(message, opts) do
+    topic = Keyword.get(opts, :topic, Config.default_topic())
+
+    if topic not in Agent.get(__MODULE__, & &1.producers) do
+      {:error, :unknown_topic}
+    else
+      key = self()
+
+      Agent.update(__MODULE__, fn state ->
+        messages = Map.get(state.messages, key, [])
+
+        %{state | messages: Map.put(state.messages, key, [message | messages])}
+      end)
+    end
+  end
+
+  def get_produced_messages() do
+    key = self()
+    
+    Agent.get(__MODULE__, fn state -> Map.get(state.messages, key) end)
+  end
+end

--- a/lib/kafka_message_bus/adapters/test_adapter.ex
+++ b/lib/kafka_message_bus/adapters/test_adapter.ex
@@ -23,9 +23,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapter do
   def produce(message, opts) do
     topic = Keyword.get(opts, :topic, Config.default_topic())
 
-    if topic not in Agent.get(__MODULE__, & &1.producers) do
-      {:error, :unknown_topic}
-    else
+    if topic in Agent.get(__MODULE__, & &1.producers) do
       key = self()
 
       Agent.update(__MODULE__, fn state ->
@@ -33,12 +31,14 @@ defmodule KafkaMessageBus.Adapters.TestAdapter do
 
         %{state | messages: Map.put(state.messages, key, [message | messages])}
       end)
+    else
+      {:error, :unknown_topic}
     end
   end
 
-  def get_produced_messages() do
+  def get_produced_messages do
     key = self()
-    
+
     Agent.get(__MODULE__, fn state -> Map.get(state.messages, key) end)
   end
 end

--- a/lib/kafka_message_bus/adapters/test_adapter.ex
+++ b/lib/kafka_message_bus/adapters/test_adapter.ex
@@ -22,6 +22,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapter do
 
   def produce(message, opts) do
     topic = Keyword.get(opts, :topic, Config.default_topic())
+    message = Poison.encode!(message)
 
     if topic in Agent.get(__MODULE__, & &1.producers) do
       key = self()

--- a/lib/kafka_message_bus/application.ex
+++ b/lib/kafka_message_bus/application.ex
@@ -8,8 +8,8 @@ defmodule KafkaMessageBus.Application do
 
     Config.get_adapters()
     |> Enum.each(fn adapter ->
-        config = Config.get_adapter_config(adapter)
-        :ok = adapter.start_link(config)
+      config = Config.get_adapter_config(adapter)
+      :ok = adapter.start_link(config)
     end)
 
     Supervisor.start_link([], strategy: :one_for_one)

--- a/lib/kafka_message_bus/application.ex
+++ b/lib/kafka_message_bus/application.ex
@@ -1,7 +1,4 @@
 defmodule KafkaMessageBus.Application do
-  @moduledoc false
-
-  alias Kaffe.GroupMemberSupervisor
   alias KafkaMessageBus.Config
 
   use Application
@@ -9,10 +6,14 @@ defmodule KafkaMessageBus.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    ([supervisor(GroupMemberSupervisor, [])] ++ Config.queue_supervisor())
-    |> Supervisor.start_link(
-      strategy: :one_for_one,
-      name: KafkaMessageBus.Supervisor
-    )
+    children = Config.get_adapters_supervisors()
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+
+    # ([supervisor(GroupMemberSupervisor, [])] ++ Config.queue_supervisor())
+    # |> Supervisor.start_link(
+    # strategy: :one_for_one,
+    # name: KafkaMessageBus.Supervisor
+    # )
   end
 end

--- a/lib/kafka_message_bus/application.ex
+++ b/lib/kafka_message_bus/application.ex
@@ -6,14 +6,12 @@ defmodule KafkaMessageBus.Application do
   def start(_type, _args) do
     import Supervisor.Spec
 
-    children = Config.get_adapters_supervisors()
+    Config.get_adapters()
+    |> Enum.each(fn adapter ->
+        config = Config.get_adapter_config(adapter)
+        :ok = adapter.start_link(config)
+    end)
 
-    Supervisor.start_link(children, strategy: :one_for_one)
-
-    # ([supervisor(GroupMemberSupervisor, [])] ++ Config.queue_supervisor())
-    # |> Supervisor.start_link(
-    # strategy: :one_for_one,
-    # name: KafkaMessageBus.Supervisor
-    # )
+    Supervisor.start_link([], strategy: :one_for_one)
   end
 end

--- a/lib/kafka_message_bus/config.ex
+++ b/lib/kafka_message_bus/config.ex
@@ -1,9 +1,26 @@
 defmodule KafkaMessageBus.Config do
-  @moduledoc false
-
   alias Supervisor.Spec
 
   @lib_name :kafka_message_bus
+
+  def get_adapters_supervisors do
+    Enum.map(get_adapters(), &build_child_spec/1)
+  end
+
+  defp build_child_spec(adapter) do
+    %{
+      id: adapter,
+      start: {adapter, :start_link, [get_adapter_config(adapter)]}
+    }
+  end
+
+  defp get_adapters do
+    Application.get_env(@lib_name, :adapters)
+  end
+
+  defp get_adapter_config(adapter) do
+    Application.get_env(@lib_name, adapter)
+  end
 
   def default_topic, do: Application.get_env(@lib_name, :default_topic)
 

--- a/lib/kafka_message_bus/config.ex
+++ b/lib/kafka_message_bus/config.ex
@@ -1,18 +1,5 @@
 defmodule KafkaMessageBus.Config do
-  alias Supervisor.Spec
-
   @lib_name :kafka_message_bus
-
-  def get_adapters_supervisors do
-    Enum.map(get_adapters(), &build_child_spec/1)
-  end
-
-  defp build_child_spec(adapter) do
-    %{
-      id: adapter,
-      start: {adapter, :start_link, [get_adapter_config(adapter)]}
-    }
-  end
 
   def get_adapters do
     Application.get_env(@lib_name, :adapters)
@@ -22,48 +9,11 @@ defmodule KafkaMessageBus.Config do
     Application.get_env(@lib_name, adapter)
   end
 
-  def default_topic, do: Application.get_env(@lib_name, :default_topic)
-
-  def source, do: Application.get_env(@lib_name, :source)
-
-  def partitioner, do: Application.get_env(@lib_name, :partitioner)
-
-  def retry_strategy, do: Application.get_env(:kafka_message_bus, :retry_strategy)
-
-  def heartbeat_interval,
-    do: Application.get_env(@lib_name, :heartbeat_interval, 1_000)
-
-  def commit_interval,
-    do: Application.get_env(@lib_name, :commit_interval, 1_000)
-
-  def topic_names do
-    @lib_name
-    |> Application.get_env(:consumers, [])
-    |> Enum.map(&elem(&1, 0))
+  def default_topic do
+    Application.get_env(@lib_name, :default_topic)
   end
 
-  def get_message_processor(topic) do
-    @lib_name
-    |> Application.get_env(:consumers, [])
-    |> Enum.filter(fn {t, _} -> t == topic end)
-    |> List.first()
-    |> elem(1)
-  end
-
-  def consumer_group_opts do
-    [
-      heartbeat_interval: heartbeat_interval(),
-      commit_interval: commit_interval()
-    ]
-  end
-
-  def queue_supervisor do
-    case retry_strategy() do
-      :exq ->
-        [Spec.supervisor(Exq, [])]
-
-      _ ->
-        []
-    end
+  def source do
+    Application.get_env(@lib_name, :source)
   end
 end

--- a/lib/kafka_message_bus/config.ex
+++ b/lib/kafka_message_bus/config.ex
@@ -14,11 +14,11 @@ defmodule KafkaMessageBus.Config do
     }
   end
 
-  defp get_adapters do
+  def get_adapters do
     Application.get_env(@lib_name, :adapters)
   end
 
-  defp get_adapter_config(adapter) do
+  def get_adapter_config(adapter) do
     Application.get_env(@lib_name, adapter)
   end
 

--- a/lib/kafka_message_bus/consumer.ex
+++ b/lib/kafka_message_bus/consumer.ex
@@ -1,6 +1,4 @@
 defmodule KafkaMessageBus.Consumer do
-  @moduledoc false
-
   alias KafkaMessageBus.ConsumerEnqueuer
 
   require Logger

--- a/lib/kafka_message_bus/consumer.ex
+++ b/lib/kafka_message_bus/consumer.ex
@@ -1,66 +1,6 @@
 defmodule KafkaMessageBus.Consumer do
-  alias KafkaMessageBus.ConsumerEnqueuer
+  @type msg_content :: Map.t()
+  @type msg_error :: String.t()
 
-  require Logger
-
-  @processor_config Application.get_env(:kafka_message_bus, :consumers)
-  @retry_strategy Application.get_env(:kafka_message_bus, :retry_strategy)
-
-  def handle_messages(nil), do: :ok
-
-  def handle_messages(messages) do
-    for message <- messages do
-      Logger.info(fn ->
-        "Got message: #{message.topic}/#{message.partition} -> #{message.key}: #{message.value}"
-      end)
-
-      message.value
-      |> Poison.decode()
-      |> process_message(message.topic)
-    end
-
-    :ok
-  end
-
-  defp process_message({:ok, msg_content}, topic) do
-    Logger.metadata(request_id: msg_content["request_id"])
-
-    Enum.each(@processor_config, &execute_message(msg_content, topic, &1))
-  end
-
-  defp process_message({:error, error}, topic) do
-    Logger.error("Failed to parse message in topic #{topic}. Error: #{inspect(error)}")
-  end
-
-  defp execute_message(
-         msg_content = %{"resource" => resource},
-         topic,
-         {topic, resource, message_processor}
-       ) do
-    Logger.debug(fn -> "[ACCEPTED] #{message_processor} - #{topic}: #{inspect(msg_content)}" end)
-
-    try do
-      message_processor.process(msg_content)
-    rescue
-      _ ->
-        enqueue_message_retry(msg_content, message_processor, @retry_strategy)
-    end
-  end
-
-  defp execute_message(%{"resource" => resource}, topic, {_, _, message_processor}) do
-    Logger.debug(fn ->
-      "[IGNORED] #{message_processor} - #{topic}: #{inspect(resource)}"
-    end)
-
-    :ok
-  end
-
-  defp enqueue_message_retry(msg_content, message_processor, retry_strategy)
-       when retry_strategy == :exq do
-    ConsumerEnqueuer.enqueue(msg_content, message_processor)
-  end
-
-  defp enqueue_message_retry(_, _, _) do
-    Logger.warn("Will not retry message")
-  end
+  @callback process(msg_content) :: :ok | {:error, msg_error}
 end

--- a/lib/kafka_message_bus/consumer/behaviour.ex
+++ b/lib/kafka_message_bus/consumer/behaviour.ex
@@ -1,8 +1,0 @@
-defmodule KafkaMessageBus.Consumer.Behaviour do
-  @moduledoc false
-
-  @type msg_content :: Map.t()
-  @type msg_error :: String.t()
-
-  @callback process(msg_content) :: :ok | {:error, msg_error}
-end

--- a/lib/kafka_message_bus/consumer_enqueuer.ex
+++ b/lib/kafka_message_bus/consumer_enqueuer.ex
@@ -1,13 +1,12 @@
 defmodule KafkaMessageBus.ConsumerEnqueuer do
-  @moduledoc false
+  @moduledoc """
+  Legacy dead letter queue handler.
+
+  This is not used directly anymore but is still necessary in case old messages
+  are being reprocessed.
+  """
 
   require Logger
-
-  @queue_name "dead_letter_queue"
-
-  def enqueue(msg_content, message_processor) do
-    Exq.enqueue(Exq, @queue_name, __MODULE__, [msg_content, message_processor])
-  end
 
   def perform(msg_content, message_processor) do
     Logger.info("Retrying message with content: #{inspect(msg_content)}")

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -1,0 +1,4 @@
+defmodule KafkaMessageBus.ConsumerHandler do
+  def perform(module, message) do
+  end
+end

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -1,4 +1,8 @@
 defmodule KafkaMessageBus.ConsumerHandler do
+  alias KafkaMessageBus.Utils
+
+  require Logger
+
   def perform(module, message) when is_binary(module) do
     module = String.to_existing_atom(module)
 
@@ -6,6 +10,10 @@ defmodule KafkaMessageBus.ConsumerHandler do
   end
 
   def perform(module, message) do
+    Logger.info(fn ->
+      "Running #{Utils.to_module_short_name(module)} message handler"
+    end)
+
     case module.process(message) do
       :ok -> :ok
       {:error, _reason} = result -> result

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -1,4 +1,12 @@
 defmodule KafkaMessageBus.ConsumerHandler do
   def perform(module, message) do
+    with :ok <- module.process(message) do
+      :ok
+    else
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e -> {:error, e}
   end
 end

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -6,11 +6,10 @@ defmodule KafkaMessageBus.ConsumerHandler do
   end
 
   def perform(module, message) do
-    with :ok <- module.process(message) do
-      :ok
-    else
-      {:error, reason} ->
-        {:error, reason}
+    case module.process(message) do
+      :ok -> :ok
+      {:error, _reason} = result -> result
+      other -> {:error, other}
     end
   rescue
     e -> {:error, e}

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -1,4 +1,10 @@
 defmodule KafkaMessageBus.ConsumerHandler do
+  def perform(module, message) when is_binary(module) do
+    module = String.to_existing_atom(module)
+
+    perform(module, message)
+  end
+
   def perform(module, message) do
     with :ok <- module.process(message) do
       :ok

--- a/lib/kafka_message_bus/producer.ex
+++ b/lib/kafka_message_bus/producer.ex
@@ -9,24 +9,23 @@ defmodule KafkaMessageBus.Producer do
     topic = Keyword.get(opts, :topic, Config.default_topic())
     source = Keyword.get(opts, :source, Config.source())
 
-    message =
-      %{
-        source: source,
-        action: action,
-        resource: resource,
-        timestamp: DateTime.utc_now(),
-        request_id: Logger.metadata() |> Keyword.get(:request_id),
-        data: data |> Map.delete(:__meta__)
-      }
+    message = %{
+      source: source,
+      action: action,
+      resource: resource,
+      timestamp: DateTime.utc_now(),
+      request_id: Logger.metadata() |> Keyword.get(:request_id),
+      data: data |> Map.delete(:__meta__)
+    }
 
     opts = Keyword.put(opts, :key, key)
 
-   	topic
-   	|> get_adapters_for_topic()
-   	|> case do
+    topic
+    |> get_adapters_for_topic()
+    |> case do
       [] -> {:error, :topic_not_found}
       adapters -> Enum.map(adapters, fn adapter -> adapter.produce(message, opts) end)
-   	end
+    end
   end
 
   defp get_adapters_for_topic(topic) do

--- a/lib/kafka_message_bus/producer.ex
+++ b/lib/kafka_message_bus/producer.ex
@@ -1,6 +1,4 @@
 defmodule KafkaMessageBus.Producer do
-  @moduledoc false
-
   require Logger
 
   alias KafkaMessageBus.Config

--- a/lib/kafka_message_bus/utils.ex
+++ b/lib/kafka_message_bus/utils.ex
@@ -4,4 +4,22 @@ defmodule KafkaMessageBus.Utils do
     |> Module.split()
     |> List.last()
   end
+
+  def set_log_metadata(message) do
+    Logger.metadata(
+      request_id: message["request_id"],
+      resource: message["resource"],
+      action: message["action"],
+      source: message["source"]
+    )
+  end
+
+  def clear_log_metadata do
+    Logger.metadata(
+      request_id: nil,
+      resource: nil,
+      action: nil,
+      source: nil
+    )
+  end
 end

--- a/lib/kafka_message_bus/utils.ex
+++ b/lib/kafka_message_bus/utils.ex
@@ -1,0 +1,7 @@
+defmodule KafkaMessageBus.Utils do
+  def to_module_short_name(adapter) do
+    adapter
+    |> Module.split()
+    |> List.last()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule KafkaMessageBus.Mixfile do
     [
       app: :kafka_message_bus,
       included_applications: included_applications(),
-      version: "4.0.0rc.1",
+      version: "4.0.0-rc.1",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule KafkaMessageBus.Mixfile do
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       description: description(),
       package: package(),
@@ -59,6 +60,14 @@ defmodule KafkaMessageBus.Mixfile do
       {:exq, "~> 0.12.1"},
       {:poison, "~> 3.0"},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
+    ]
+  end
+
+  defp aliases do
+    [
+      lint: [
+        "credo suggest --ignore-checks moduledoc,aliasusage,maxlinelength,aliasorder --strict"
+      ]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,6 @@ defmodule KafkaMessageBus.Mixfile do
 
   def application do
     [
-      applications: [:poison, :logger],
       mod: {KafkaMessageBus.Application, []}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,9 @@ defmodule KafkaMessageBus.Mixfile do
   def project do
     [
       app: :kafka_message_bus,
+      included_applications: included_applications(),
       version: "3.0.0",
-      elixir: "~> 1.7.4",
+      elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -46,11 +47,18 @@ defmodule KafkaMessageBus.Mixfile do
     ]
   end
 
+  defp included_applications() do
+    [
+    	:kaffe,
+    	:exq
+	  ]
+  end
+
   defp deps do
     [
       {:kaffe, "~> 1.11"},
       {:exq, "~> 0.12.1"},
-      {:poison, "~> 4.0"},
+      {:poison, "~> 3.0"},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule KafkaMessageBus.Mixfile do
     [
       {:kaffe, "~> 1.11"},
       {:exq, "~> 0.12.1"},
-      {:poison, "~> 3.0"},
+      {:jason, "~> 1.1"},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -49,9 +49,9 @@ defmodule KafkaMessageBus.Mixfile do
 
   defp included_applications() do
     [
-    	:kaffe,
-    	:exq
-	  ]
+      :kaffe,
+      :exq
+    ]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule KafkaMessageBus.Mixfile do
     [
       {:kaffe, "~> 1.11"},
       {:exq, "~> 0.12.1"},
-      {:jason, "~> 1.1"},
+      {:poison, "~> 3.0"},
       {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,19 +1,20 @@
 defmodule KafkaMessageBus.Mixfile do
   use Mix.Project
 
-  def project,
-    do: [
+  def project do
+    [
       app: :kafka_message_bus,
       version: "3.0.0",
-      elixir: "~> 1.6.5",
+      elixir: "~> 1.7.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),
       package: package(),
       name: "KafkaMessageBus",
-      source_url: "https://github.com/heckfer/kafka_message_bus"
+      source_url: "https://github.com/CampGladiator/kafka_message_bus"
     ]
+  end
 
   defp description do
     """
@@ -28,23 +29,29 @@ defmodule KafkaMessageBus.Mixfile do
         "Eduardo Cunha",
         "Fernando Heck",
         "Gabriel Alves",
-        "Matthias Nunes"
+        "Matthias Nunes",
+        "Gabriel Machado"
       ],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/heckfer/kafka_message_bus"}
+      links: %{
+        "GitHub" => "https://github.com/CampGladiator/kafka_message_bus"
+      }
     ]
   end
 
   def application do
-    [applications: [:logger, :kaffe], mod: {KafkaMessageBus.Application, []}]
+    [
+      applications: [:poison, :logger],
+      mod: {KafkaMessageBus.Application, []}
+    ]
   end
 
-  defp deps,
-    do: [
-      {:kaffe, "~> 1.9"},
+  defp deps do
+    [
+      {:kaffe, "~> 1.11"},
       {:exq, "~> 0.12.1"},
-      {:poison, "~> 3.1"},
-      {:credo, "~> 0.9.3", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.18.4", only: :dev}
+      {:poison, "~> 4.0"},
+      {:credo, "~> 1.0", only: [:dev, :test], runtime: false}
     ]
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule KafkaMessageBus.Mixfile do
     [
       app: :kafka_message_bus,
       included_applications: included_applications(),
-      version: "3.0.0",
+      version: "4.0.0rc.1",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,16 +1,64 @@
 %{
-  "brod": {:hex, :brod, "3.5.1", "9dc0d8fbd3a34a22721a789992923d56cbe8d119e0f30a171ea778ff79de6d4b", [:make, :rebar, :rebar3], [{:kafka_protocol, "1.1.2", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
-  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "exq": {:hex, :exq, "0.12.1", "4436f1311afd3f608197123717d0e5761a059a59360b657a263ab3c4204dd9d7", [:mix], [{:elixir_uuid, ">= 1.2.0", [hex: :elixir_uuid, repo: "hexpm", optional: false]}, {:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}, {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}], "hexpm"},
-  "kaffe": {:hex, :kaffe, "1.9.0", "1238dab39c2febde531e2096995cc674de48a96f4a00f6a4d919e0b1d0193c5e", [:mix], [{:brod, "~> 3.0", [hex: :brod, repo: "hexpm", optional: false]}], "hexpm"},
-  "kafka_protocol": {:hex, :kafka_protocol, "1.1.2", "96d09c4287377795ae2c488aceae2dc6872b94edba8309a27ace933d9ae32333", [:rebar, :rebar3], [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "redix": {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
-  "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm"},
-  "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], [], "hexpm"},
+  brod:
+    {:hex, :brod, "3.4.0", "34664713baaa60aed3b560c6a679cf90ace8dde8672732e730218db57440e37a",
+     [:make, :rebar, :rebar3],
+     [
+       {:kafka_protocol, "1.1.2", [hex: :kafka_protocol, repo: "hexpm", optional: false]},
+       {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  bunt:
+    {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38",
+     [:mix], [], "hexpm"},
+  connection:
+    {:hex, :connection, "1.0.4",
+     "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  credo:
+    {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f",
+     [:mix],
+     [
+       {:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]},
+       {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  earmark:
+    {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761",
+     [:mix], [], "hexpm"},
+  elixir_uuid:
+    {:hex, :elixir_uuid, "1.2.0",
+     "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
+  ex_doc:
+    {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949",
+     [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  exq:
+    {:hex, :exq, "0.12.1", "4436f1311afd3f608197123717d0e5761a059a59360b657a263ab3c4204dd9d7",
+     [:mix],
+     [
+       {:elixir_uuid, ">= 1.2.0", [hex: :elixir_uuid, repo: "hexpm", optional: false]},
+       {:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]},
+       {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}
+     ], "hexpm"},
+  jason:
+    {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7",
+     [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  kaffe:
+    {:hex, :kaffe, "1.11.0", "7bac255d1a1d242237a3d1e489a7bef52ef1e593bf1eedfb1a4b938c38d80777",
+     [:mix], [{:brod, ">= 3.0.0 and < 3.5.0", [hex: :brod, repo: "hexpm", optional: false]}],
+     "hexpm"},
+  kafka_protocol:
+    {:hex, :kafka_protocol, "1.1.2",
+     "96d09c4287377795ae2c488aceae2dc6872b94edba8309a27ace933d9ae32333", [:rebar, :rebar3],
+     [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
+  poison:
+    {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae",
+     [:mix], [], "hexpm"},
+  redix:
+    {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163",
+     [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}],
+     "hexpm"},
+  snappyer:
+    {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556",
+     [:make, :rebar, :rebar3], [], "hexpm"},
+  supervisor3:
+    {:hex, :supervisor3, "1.1.5",
+     "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3],
+     [], "hexpm"}
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,64 +1,17 @@
 %{
-  brod:
-    {:hex, :brod, "3.4.0", "34664713baaa60aed3b560c6a679cf90ace8dde8672732e730218db57440e37a",
-     [:make, :rebar, :rebar3],
-     [
-       {:kafka_protocol, "1.1.2", [hex: :kafka_protocol, repo: "hexpm", optional: false]},
-       {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}
-     ], "hexpm"},
-  bunt:
-    {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38",
-     [:mix], [], "hexpm"},
-  connection:
-    {:hex, :connection, "1.0.4",
-     "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  credo:
-    {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f",
-     [:mix],
-     [
-       {:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]},
-       {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}
-     ], "hexpm"},
-  earmark:
-    {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761",
-     [:mix], [], "hexpm"},
-  elixir_uuid:
-    {:hex, :elixir_uuid, "1.2.0",
-     "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
-  ex_doc:
-    {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949",
-     [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  exq:
-    {:hex, :exq, "0.12.1", "4436f1311afd3f608197123717d0e5761a059a59360b657a263ab3c4204dd9d7",
-     [:mix],
-     [
-       {:elixir_uuid, ">= 1.2.0", [hex: :elixir_uuid, repo: "hexpm", optional: false]},
-       {:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]},
-       {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}
-     ], "hexpm"},
-  jason:
-    {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7",
-     [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  kaffe:
-    {:hex, :kaffe, "1.11.0", "7bac255d1a1d242237a3d1e489a7bef52ef1e593bf1eedfb1a4b938c38d80777",
-     [:mix], [{:brod, ">= 3.0.0 and < 3.5.0", [hex: :brod, repo: "hexpm", optional: false]}],
-     "hexpm"},
-  kafka_protocol:
-    {:hex, :kafka_protocol, "1.1.2",
-     "96d09c4287377795ae2c488aceae2dc6872b94edba8309a27ace933d9ae32333", [:rebar, :rebar3],
-     [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
-  poison:
-    {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae",
-     [:mix], [], "hexpm"},
-  redix:
-    {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163",
-     [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}],
-     "hexpm"},
-  snappyer:
-    {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556",
-     [:make, :rebar, :rebar3], [], "hexpm"},
-  supervisor3:
-    {:hex, :supervisor3, "1.1.5",
-     "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3],
-     [], "hexpm"}
+  "brod": {:hex, :brod, "3.4.0", "34664713baaa60aed3b560c6a679cf90ace8dde8672732e730218db57440e37a", [:make, :rebar, :rebar3], [{:kafka_protocol, "1.1.2", [hex: :kafka_protocol, repo: "hexpm", optional: false]}, {:supervisor3, "1.1.5", [hex: :supervisor3, repo: "hexpm", optional: false]}], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "exq": {:hex, :exq, "0.12.1", "4436f1311afd3f608197123717d0e5761a059a59360b657a263ab3c4204dd9d7", [:mix], [{:elixir_uuid, ">= 1.2.0", [hex: :elixir_uuid, repo: "hexpm", optional: false]}, {:poison, ">= 1.2.0 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: false]}, {:redix, ">= 0.5.0", [hex: :redix, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "kaffe": {:hex, :kaffe, "1.11.0", "7bac255d1a1d242237a3d1e489a7bef52ef1e593bf1eedfb1a4b938c38d80777", [:mix], [{:brod, ">= 3.0.0 and < 3.5.0", [hex: :brod, repo: "hexpm", optional: false]}], "hexpm"},
+  "kafka_protocol": {:hex, :kafka_protocol, "1.1.2", "96d09c4287377795ae2c488aceae2dc6872b94edba8309a27ace933d9ae32333", [:rebar, :rebar3], [{:snappyer, "1.2.1", [hex: :snappyer, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "redix": {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "snappyer": {:hex, :snappyer, "1.2.1", "06c5f5c8afe80ba38e94e1ca1bd9253de95d8f2c85b08783e8d0f63815580556", [:make, :rebar, :rebar3], [], "hexpm"},
+  "supervisor3": {:hex, :supervisor3, "1.1.5", "5f3c487a6eba23de0e64c06e93efa0eca06f40324a6412c1318c77aca6da8424", [:make, :rebar, :rebar3], [], "hexpm"},
 }

--- a/test/kafka_message_bus_test.exs
+++ b/test/kafka_message_bus_test.exs
@@ -1,7 +1,0 @@
-defmodule KafkaMessageBusTest do
-  use ExUnit.Case
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-end


### PR DESCRIPTION
Library rewrite:

- Adapter based interfacing
- Hides both Kaffe and Exq from clients
- Has a general purpose test adapter

Current issues:

- An `exq` configuration is necessary on clients when using `exq_ui` due to complications on how the app tree is built