### PR TITLE
Add a producer utility macro

### DIFF
--- a/lib/kafka_message_bus.ex
+++ b/lib/kafka_message_bus.ex
@@ -4,4 +4,18 @@ defmodule KafkaMessageBus do
   def produce(data, key, resource, action, opts \\ []) do
     Producer.produce(data, key, resource, action, opts)
   end
+
+  defp producer(opts) do
+    {resource, opts} = Keyword.pop(opts, :resource)
+
+    quote do
+      defp produce(message, key, action) do
+        unquote(__MODULE__).produce(message, key, unquote(resource), action, unquote(opts))
+      end
+    end
+  end
+
+  defmacro __using__([{which, opts}]) do
+    apply(__MODULE__, which, [opts])
+  end
 end


### PR DESCRIPTION
Adds a producer utility macro that allows a module to define it's default options, providing it with a `produce` function that uses them.