### PR TITLE
Serialize dead letter queue errors with the default Elixir representation

### DIFF
--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -62,7 +62,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
           }"
         end)
 
-        message = %{"message" => message, "consumer" => consumer, "previous_error" => reason}
+        message = %{"message" => message, "consumer" => consumer, "previous_error" => inspect(reason)}
 
         KafkaMessageBus.produce(message, nil, "failure", "retry", topic: "dead_letter_queue")
     end


### PR DESCRIPTION
This allows preserving Elixir structs (exceptions, tuples).