### PR TITLE
Allow no consumers or producers on the Kaffe adapter config

### DIFF
--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -62,7 +62,11 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
           }"
         end)
 
-        message = %{"message" => message, "consumer" => consumer, "previous_error" => inspect(reason)}
+        message = %{
+          "message" => message,
+          "consumer" => consumer,
+          "previous_error" => inspect(reason)
+        }
 
         KafkaMessageBus.produce(message, nil, "failure", "retry", topic: "dead_letter_queue")
     end


### PR DESCRIPTION
If no consumers are found, the first producer topic is used as a consumer topic. Kaffe does not allow for an application to only produce messages.