### PR TITLE
[MARS-1035] Producer Don't Filter Ecto Associations

### DIFF
--- a/lib/kafka_message_bus/messages/message_data/map_util.ex
+++ b/lib/kafka_message_bus/messages/message_data/map_util.ex
@@ -27,7 +27,8 @@ defmodule KafkaMessageBus.Messages.MessageData.MapUtil do
 
           value when is_map(value) === true ->
             {:ok, struct_value} =
-              Map.get(struct, key)
+              struct
+              |> Map.get(key)
               |> deep_to_struct(value)
 
             %{acc | key => struct_value}

--- a/lib/kafka_message_bus/messages/message_data/map_util.ex
+++ b/lib/kafka_message_bus/messages/message_data/map_util.ex
@@ -4,6 +4,7 @@ defmodule KafkaMessageBus.Messages.MessageData.MapUtil do
   """
   require Logger
 
+  def deep_to_struct(struct, message_data \\ %{})
   def deep_to_struct(nil, %{} = _message_data), do: {:ok, nil}
   def deep_to_struct(struct, nil), do: {:ok, struct}
 

--- a/lib/kafka_message_bus/producer.ex
+++ b/lib/kafka_message_bus/producer.ex
@@ -3,8 +3,9 @@ defmodule KafkaMessageBus.Producer do
   This is the module that contains the producer functions. It is used directly
   by the KafkaMessageBus module.
   """
-  alias KafkaMessageBus.{Config, MessageDataValidator}
+  alias KafkaMessageBus.Messages.MessageData.MapUtil
   alias KafkaMessageBus.Producer.AdapterHandler
+  alias KafkaMessageBus.{Config, MessageDataValidator}
   require Logger
 
   def produce(data, key, resource, action, opts \\ []) do
@@ -84,7 +85,12 @@ defmodule KafkaMessageBus.Producer do
     |> adapter_handler.process_adapters(opts, topic)
   end
 
-  defp remove_meta(data) when is_map(data), do: Map.drop(data, [:__meta__, :__struct__])
+  defp remove_meta(data) when is_map(data) do
+    with {:ok, updated_data} <- MapUtil.deep_to_struct(data) do
+      Map.drop(updated_data, [:__meta__, :__struct__])
+    end
+  end
+
   defp remove_meta(data), do: data
 
   def get_produce_info(data, key, resource, action, opts, topic) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KafkaMessageBus.Mixfile do
   def project do
     [
       app: :kafka_message_bus,
-      version: "4.2.8",
+      version: "4.2.9",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/kafka_message_bus/producer_test.exs
+++ b/test/kafka_message_bus/producer_test.exs
@@ -3,6 +3,7 @@ defmodule KafkaMessageBus.ProducerTest do
   use ExUnit.Case
 
   alias KafkaMessageBus.Adapters.TestAdapter
+  alias KafkaMessageBus.Examples.SampleMessageData
   alias KafkaMessageBus.Producer
 
   @moduletag :capture_log
@@ -65,6 +66,19 @@ defmodule KafkaMessageBus.ProducerTest do
       end
 
       assert capture_log(fun) =~ "[info]  Message contract (produce) excluded"
+    end
+
+    test "it produces messages without Ecto Association Not Loaded" do
+      message = %SampleMessageData{
+        id: "ID_1",
+        field1: "abc",
+        field2: "2019-10-11T10:09:08Z",
+        field3: struct(Ecto.Association.NotLoaded, %{})
+      }
+
+      assert :ok == Producer.produce(message, "key", "sample_resource", "sample_action")
+      assert [produced_message] = TestAdapter.get_produced_messages()
+      assert is_nil(produced_message["data"]["field3"])
     end
   end
 


### PR DESCRIPTION
## Motivation
Basically, `checkin-service` tests are failing because the most updated version of this library doesn't filter the `Ecto.Association.NotLoaded`.

I've bumped the version on `mix.exs` to `4.2.9` since it was on `4.2.8`, yet, there was no release at GitHub with the tag `4.2.8`.

## How to Test
Update the `checkin_service#mix.ex` to use the local version of this library.

Example:

```elixir
# ...
{:kafka_message_bus, "~> 4.2.8", path: "/path/to/kafka_message_bus", override: true},
# ...
```