### PR TITLE
[LIT-105] Format Kafka Message Bus

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -81,8 +81,7 @@
         # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
         #
-        {Credo.Check.Design.AliasUsage,
-         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+        {Credo.Check.Design.AliasUsage, [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,20 +1,6 @@
 [
-  inputs: [
-    "{config,lib,test}/**/*.{ex,exs}",
-    "mix.exs"
-  ],
-  locals_without_parens: [
-    # Formatter tests
-    assert_format: 2,
-    assert_format: 3,
-    assert_same: 1,
-    assert_same: 2,
-
-    # Errors tests
-    assert_eval_raise: 3,
-
-    # Mix tests
-    in_fixture: 2,
-    in_tmp: 2
-  ]
+  import_deps: [:ecto],
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 120,
+  subdirectories: ["priv/*/migrations"]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,7 @@ config :kafka_message_bus,
 config :kafka_message_bus, KafkaMessageBus.Adapters.Exq,
   consumers: [
     {"job_queue", "job_resource", KafkaMessageBusTest.Adapters.Exq.CustomJobConsumer},
-    {"dead_letter_queue", nil, KafkaMessageBus.Adapters.Exq.DeadLetterQueueConsumer,
-     concurrency: 600}
+    {"dead_letter_queue", nil, KafkaMessageBus.Adapters.Exq.DeadLetterQueueConsumer, concurrency: 600}
   ],
   producers: ["job_queue", "dead_letter_queue"],
   endpoints: [localhost: 6379],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,5 +5,4 @@ config :logger,
 
 config :kafka_message_bus, :message_contracts,
   exclusions: :none,
-  message_data_factory_implementation:
-    KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation
+  message_data_factory_implementation: KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,10 +10,8 @@ config :kafka_message_bus,
   default_topic: "default_topic",
   adapters: [KafkaMessageBus.Adapters.TestAdapter]
 
-config :kafka_message_bus, KafkaMessageBus.Adapters.TestAdapter,
-  producers: ["default_topic", "secondary_topic"]
+config :kafka_message_bus, KafkaMessageBus.Adapters.TestAdapter, producers: ["default_topic", "secondary_topic"]
 
 config :kafka_message_bus, :message_contracts,
   exclusions: [KafkaMessageBus.Examples.SampleExclusion],
-  message_data_factory_implementation:
-    KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation
+  message_data_factory_implementation: KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation

--- a/lib/kafka_message_bus/adapters/kaffe/consumer.ex
+++ b/lib/kafka_message_bus/adapters/kaffe/consumer.ex
@@ -60,9 +60,7 @@ defmodule KafkaMessageBus.Adapters.Kaffe.Consumer do
 
       {:error, reason} ->
         Logger.error(fn ->
-          "Failed to run handler - will produce `dead_letter_queue` message. Reason: #{
-            inspect(reason)
-          }"
+          "Failed to run handler - will produce `dead_letter_queue` message. Reason: #{inspect(reason)}"
         end)
 
         message = %{

--- a/lib/kafka_message_bus/adapters/test_adapter.ex
+++ b/lib/kafka_message_bus/adapters/test_adapter.ex
@@ -60,8 +60,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapter do
       state.messages
       |> Map.get(key, [])
       |> Enum.filter(fn message ->
-        message["topic"] == topic and message["resource"] == resource and
-          message["action"] == action
+        message["topic"] == topic and message["resource"] == resource and message["action"] == action
       end)
     end)
   end

--- a/lib/kafka_message_bus/consumer_handler.ex
+++ b/lib/kafka_message_bus/consumer_handler.ex
@@ -32,9 +32,7 @@ defmodule KafkaMessageBus.ConsumerHandler do
 
       {:error, [] = validation_errors} ->
         Logger.warn(fn ->
-          "Validation failed for message_data consumption: #{inspect(validation_errors)}\n#{
-            inspect(message)
-          }"
+          "Validation failed for message_data consumption: #{inspect(validation_errors)}\n#{inspect(message)}"
         end)
 
         {:error, validation_errors}

--- a/lib/kafka_message_bus/messages/message_data/map_util.ex
+++ b/lib/kafka_message_bus/messages/message_data/map_util.ex
@@ -87,9 +87,7 @@ defmodule KafkaMessageBus.Messages.MessageData.MapUtil do
   Default function returns an error.
   """
   def safe_get(map, field_name),
-    do:
-      {:error,
-       "Unexpected param encountered. map: #{inspect(map)}, field_name: #{inspect(field_name)}"}
+    do: {:error, "Unexpected param encountered. map: #{inspect(map)}, field_name: #{inspect(field_name)}"}
 
   defp atom_to_string(nil, map, field_name), do: Map.get(map, Atom.to_string(field_name))
   defp atom_to_string(value, _map, _field_name), do: value
@@ -98,8 +96,7 @@ defmodule KafkaMessageBus.Messages.MessageData.MapUtil do
     Map.get(map, String.to_existing_atom(field_name))
   rescue
     e ->
-      err_msg =
-        "Failed to convert field_name '#{field_name}' to an existing atom. ERR: #{inspect(e)}"
+      err_msg = "Failed to convert field_name '#{field_name}' to an existing atom. ERR: #{inspect(e)}"
 
       Logger.warn(fn -> err_msg end)
       {:error, err_msg}

--- a/lib/kafka_message_bus/messages/message_data/unrecognized_message_data_type.ex
+++ b/lib/kafka_message_bus/messages/message_data/unrecognized_message_data_type.ex
@@ -8,9 +8,7 @@ defmodule KafkaMessageBus.Messages.MessageData.UnrecognizedMessageDataType do
         require Logger
 
         fn ->
-          "Encountered unrecognized message type for resource: #{resource}, action: #{action}. #{
-            inspect(data)
-          }"
+          "Encountered unrecognized message type for resource: #{resource}, action: #{action}. #{inspect(data)}"
         end
         |> Logger.warn()
 

--- a/lib/kafka_message_bus/producer.ex
+++ b/lib/kafka_message_bus/producer.ex
@@ -14,9 +14,7 @@ defmodule KafkaMessageBus.Producer do
       case MessageDataValidator.validate(data, resource, action) do
         {:ok, :message_contract_excluded} ->
           Logger.info(fn ->
-            "Message contract (produce) excluded: resource=#{inspect(resource)}, action=#{
-              inspect(action)
-            }"
+            "Message contract (produce) excluded: resource=#{inspect(resource)}, action=#{inspect(action)}"
           end)
 
           on_produce(data, key, resource, action, opts, topic)
@@ -53,8 +51,7 @@ defmodule KafkaMessageBus.Producer do
 
       Logger.error(fn ->
         "Unhandled error encountered in Producer.produce/5: #{inspect(err)}\n" <>
-          "stacktrace: #{trace}\n" <>
-          "produce_info: #{get_produce_info(data, key, resource, action, opts, nil)}"
+          "stacktrace: #{trace}\n" <> "produce_info: #{get_produce_info(data, key, resource, action, opts, nil)}"
       end)
 
       reraise err, __STACKTRACE__
@@ -66,9 +63,7 @@ defmodule KafkaMessageBus.Producer do
     Logger.info(fn ->
       key_log = if key != nil, do: "(key: #{key}) ", else: ""
 
-      "Producing message on #{inspect(key_log)}:#{inspect(topic)}:#{inspect(resource)}:#{
-        inspect(action)
-      }"
+      "Producing message on #{inspect(key_log)}:#{inspect(topic)}:#{inspect(resource)}:#{inspect(action)}"
     end)
 
     opts = Keyword.put(opts, :key, key)
@@ -104,15 +99,13 @@ defmodule KafkaMessageBus.Producer do
 
   def get_produce_info(data, key, resource, action, opts, topic) do
     produce_info =
-      "key: #{inspect(key)}, resource: #{inspect(resource)}, action: #{inspect(action)}, topic: #{
-        inspect(topic)
-      }, opts: #{inspect(opts)}, message_data: #{inspect(data)}"
+      "key: #{inspect(key)}, resource: #{inspect(resource)}, action: #{inspect(action)}, topic: #{inspect(topic)}, opts: #{
+        inspect(opts)
+      }, message_data: #{inspect(data)}"
 
     if action =~ "nation_" do
       Logger.warn(fn ->
-        "Realm module is attempting to produce a message that appears to originate from nation: #{
-          produce_info
-        }"
+        "Realm module is attempting to produce a message that appears to originate from nation: #{produce_info}"
       end)
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KafkaMessageBus.Mixfile do
   def project do
     [
       app: :kafka_message_bus,
-      version: "4.2.11",
+      version: "4.2.12",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/consumer_handler_test.exs
+++ b/test/consumer_handler_test.exs
@@ -62,8 +62,7 @@ defmodule KafkaMessageBus.ConsumerHandlerTest do
       assert err_list == [{:field2, {"is invalid", [type: :utc_datetime, validation: :cast]}}]
     end
 
-    assert capture_log(fun) =~
-             "Unexpected response encountered when validating consumer message data"
+    assert capture_log(fun) =~ "Unexpected response encountered when validating consumer message data"
   end
 
   test "unrecognized action will attempt to process anyway" do

--- a/test/kafka_message_bus/adapters/exq/consumer_test.exs
+++ b/test/kafka_message_bus/adapters/exq/consumer_test.exs
@@ -14,8 +14,7 @@ defmodule KafkaMessageBus.Adapters.Exq.ConsumerTest do
 
       assert capture_log(fun) =~ "[info]  Received Exq message"
 
-      assert capture_log(fun) =~
-               "MockConsumerHandler: %{\"field1\" => \"value1\", \"field2\" => \"value2\"}"
+      assert capture_log(fun) =~ "MockConsumerHandler: %{\"field1\" => \"value1\", \"field2\" => \"value2\"}"
     end
 
     test "rethrown exceptions" do
@@ -41,8 +40,7 @@ defmodule KafkaMessageBus.Adapters.Exq.ConsumerTest do
         end)
       end
 
-      assert capture_log(fun) =~
-               "[error] consumer_handler.perform failed due to: \"Something went afoul!\""
+      assert capture_log(fun) =~ "[error] consumer_handler.perform failed due to: \"Something went afoul!\""
     end
   end
 end

--- a/test/kafka_message_bus/adapters/test_adapter_test.exs
+++ b/test/kafka_message_bus/adapters/test_adapter_test.exs
@@ -23,8 +23,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapterTest do
 
   describe "getting specific produced messages" do
     test "it should return an empty list if no messages are produced with filters" do
-      messages =
-        TestAdapter.get_produced_messages("default_topic", "some_resource", "some_action")
+      messages = TestAdapter.get_produced_messages("default_topic", "some_resource", "some_action")
 
       assert Enum.empty?(messages)
     end
@@ -37,9 +36,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapterTest do
       KafkaMessageBus.produce(first_message, "key", "resource", "action")
       KafkaMessageBus.produce(second_message, "key", "resource", "action")
 
-      KafkaMessageBus.produce(third_message, "key", "other_resource", "action",
-        topic: "secondary_topic"
-      )
+      KafkaMessageBus.produce(third_message, "key", "other_resource", "action", topic: "secondary_topic")
 
       produced_messages = TestAdapter.get_produced_messages("default_topic", "resource", "action")
 
@@ -92,9 +89,7 @@ defmodule KafkaMessageBus.Adapters.TestAdapterTest do
       parent = self()
 
       spawn(fn ->
-        KafkaMessageBus.produce(second_message, "key", "other_resource", "action",
-          topic: "secondary_topic"
-        )
+        KafkaMessageBus.produce(second_message, "key", "other_resource", "action", topic: "secondary_topic")
 
         send(parent, :done)
       end)

--- a/test/kafka_message_bus/config_test.exs
+++ b/test/kafka_message_bus/config_test.exs
@@ -38,8 +38,7 @@ defmodule KafkaMessageBus.ConfigTest do
     test "message_contracts" do
       assert Config.message_contracts!() == [
                exclusions: [KafkaMessageBus.Examples.SampleExclusion],
-               message_data_factory_implementation:
-                 KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation
+               message_data_factory_implementation: KafkaMessageBus.Examples.SampleMessageDataFactoryImplementation
              ]
     end
   end

--- a/test/kafka_message_bus/examples/sample_message_data_factory_implementation_test.exs
+++ b/test/kafka_message_bus/examples/sample_message_data_factory_implementation_test.exs
@@ -5,8 +5,7 @@ defmodule KafkaMessageBus.Messages.MessageData.SampleMessageDataFactoryImplement
 
   test "returns mapped message data types" do
     fun = fn ->
-      {:ok, result} =
-        SampleMessageDataFactoryImplementation.on_create(%{}, "sample_resource", "sample_action")
+      {:ok, result} = SampleMessageDataFactoryImplementation.on_create(%{}, "sample_resource", "sample_action")
 
       assert result.__struct__ == KafkaMessageBus.Examples.SampleMessageData
     end
@@ -16,8 +15,7 @@ defmodule KafkaMessageBus.Messages.MessageData.SampleMessageDataFactoryImplement
 
   test "can be validated" do
     fun = fn ->
-      {:error, result} =
-        SampleMessageDataFactoryImplementation.on_create(%{}, "unknown", "sample_action")
+      {:error, result} = SampleMessageDataFactoryImplementation.on_create(%{}, "unknown", "sample_action")
 
       assert result == :unrecognized_message_data_type
     end

--- a/test/kafka_message_bus/messages/message_data/factory_test.exs
+++ b/test/kafka_message_bus/messages/message_data/factory_test.exs
@@ -27,8 +27,7 @@ defmodule KafkaMessageBus.Messages.MessageData.FactoryTest do
 
     test "exclusions list returns message to bypass message enforcement on factory match" do
       fun = fn ->
-        {:ok, sample_data} =
-          Factory.create(%{}, "sample_resource", "sample_action", [SampleMessageData])
+        {:ok, sample_data} = Factory.create(%{}, "sample_resource", "sample_action", [SampleMessageData])
 
         assert sample_data == :message_contract_excluded
       end
@@ -55,8 +54,7 @@ defmodule KafkaMessageBus.Messages.MessageData.FactoryTest do
         assert err_msg == :unexpected_message_contract_exclusions
       end
 
-      assert capture_log(fun) =~
-               "[error] Unexpected value for message_contract_exclusions: \"not valid\""
+      assert capture_log(fun) =~ "[error] Unexpected value for message_contract_exclusions: \"not valid\""
     end
   end
 

--- a/test/kafka_message_bus/messages/message_data/map_util_test.exs
+++ b/test/kafka_message_bus/messages/message_data/map_util_test.exs
@@ -45,8 +45,7 @@ defmodule KafkaMessageBus.MapUtilTest do
 
     test "trying to get from types other than maps results in an error" do
       assert MapUtil.safe_get("not-a-map", "test_id") ==
-               {:error,
-                "Unexpected param encountered. map: \"not-a-map\", field_name: \"test_id\""}
+               {:error, "Unexpected param encountered. map: \"not-a-map\", field_name: \"test_id\""}
     end
   end
 

--- a/test/kafka_message_bus/messages/message_data_validator_test.exs
+++ b/test/kafka_message_bus/messages/message_data_validator_test.exs
@@ -75,8 +75,7 @@ defmodule KafkaMessageBus.MessageDataValidatorTest do
 
       assert Enum.count(err_list) == 1
 
-      assert Enum.at(err_list, 0) ==
-               {:field2, {"is invalid", [type: :utc_datetime, validation: :cast]}}
+      assert Enum.at(err_list, 0) == {:field2, {"is invalid", [type: :utc_datetime, validation: :cast]}}
     end
 
     assert capture_log(fun) =~ "[info]  Creating for sample_resource and sample_action"

--- a/test/kafka_message_bus/producer/adapter_hander_test.exs
+++ b/test/kafka_message_bus/producer/adapter_hander_test.exs
@@ -41,8 +41,7 @@ defmodule KafkaMessageBus.Producer.AdapterHandlerTest do
 
       assert capture_log(fun) =~ "[debug] Producing message with TestAdapter adapter"
 
-      assert capture_log(fun) =~
-               "[error] Failed to send message using TestAdapter: {:error, :something_bad_happened}"
+      assert capture_log(fun) =~ "[error] Failed to send message using TestAdapter: {:error, :something_bad_happened}"
     end
 
     test "should return error if provided empty list of adapters" do


### PR DESCRIPTION
I’ve updated the `formatter` to use rules similar to a newly created `Phoenix` project, with only one change: the `line_length` to be `120`. (Same used on other services.)

However, this one don’t use the `import_deps` from `phoenix` since `phoenix` is not a dependency on this project.
